### PR TITLE
Feature/swap positions on navbar

### DIFF
--- a/app/src/frontend/header.js
+++ b/app/src/frontend/header.js
@@ -16,19 +16,19 @@ const Header = (props) => (
                     <a className="nav-link" href="https://pages.colouring.london">Hello</a>
                 </li>
                 <li className="nav-item">
+                    <a className="nav-link" href="https://pages.colouring.london/buildingcategories">Data Categories</a>
+                </li>
+                <li className="nav-item">
                     <NavLink to="/view/age.html" className="nav-link">View Maps</NavLink>
                 </li>
                 <li className="nav-item">
                     <NavLink to="/edit/age.html" className="nav-link">Add/Edit Data</NavLink>
                 </li>
-                <li className="nav-item">
-                    <a className="nav-link" href="https://pages.colouring.london/buildingcategories">Building Categories</a>
+                 <li className="nav-item">
+                    <a className="nav-link" href="https://pages.colouring.london/about">More about</a>
                 </li>
                 <li className="nav-item">
                     <a className="nav-link" href="https://pages.colouring.london/whoisinvolved">Who's Involved?</a>
-                </li>
-                <li className="nav-item">
-                    <a className="nav-link" href="https://pages.colouring.london/about">More about</a>
                 </li>
                 <li className="nav-item">
                     <a className="nav-link" href="https://discuss.colouring.london">Discuss</a>

--- a/app/src/frontend/header.js
+++ b/app/src/frontend/header.js
@@ -24,7 +24,7 @@ const Header = (props) => (
                 <li className="nav-item">
                     <NavLink to="/edit/age.html" className="nav-link">Add/Edit Data</NavLink>
                 </li>
-                 <li className="nav-item">
+                <li className="nav-item">
                     <a className="nav-link" href="https://pages.colouring.london/about">More about</a>
                 </li>
                 <li className="nav-item">


### PR DESCRIPTION
Fix for issue #146 Swap position of ' More about' on toolbar with 'Building categories' & rename latter.
