### PR TITLE
Fix/clear map cache

### DIFF
--- a/app/src/index.js
+++ b/app/src/index.js
@@ -2,8 +2,10 @@
  * Load server and listen
  *
  */
-import app from './server';
 import http from 'http';
+
+import app from './server';
+
 
 const server = http.createServer(app);
 
@@ -17,6 +19,7 @@ server.listen(process.env.PORT || 3000, error => {
   console.log('🚀  started');
 });
 
+// In development mode, enable hot module reloading (HMR)
 if (module.hot) {
   console.log('✅  Server-side HMR Enabled!');
 

--- a/app/src/parse.js
+++ b/app/src/parse.js
@@ -1,11 +1,13 @@
 /**
  * Utility functions for parsing
+ *
  */
 
 /**
  * Parse a string as positive integer or NaN
  *
  * @param {string} value
+ * @returns {number} integer or NaN
  */
 function strictParseInt(value) {
     if (/^([1-9][0-9]*)$/.test(value))
@@ -13,7 +15,12 @@ function strictParseInt(value) {
     return NaN;
 }
 
-
+/**
+ * Parse building ID from URL
+ *
+ * @param {String} url
+ * @returns {number|undefined}
+ */
 function parseBuildingURL(url) {
     const re = /\/building\/([^/]+).html/;
     const matches = re.exec(url);
@@ -24,6 +31,12 @@ function parseBuildingURL(url) {
     return undefined;
 }
 
+/**
+ * Parse category slug from URL
+ *
+ * @param {String} url
+ * @returns {String} [age]
+ */
 function parseCategoryURL(url) {
     const default_cat = 'age';
     if (url === "/") {

--- a/app/src/tiles/cache.js
+++ b/app/src/tiles/cache.js
@@ -18,40 +18,143 @@
 // and then use stdlib `import fs from 'fs';`
 import fs from 'node-fs';
 
+import { get_xyz } from './tile';
+
+// Use an environment variable to configure the cache location, somewhere we can read/write to.
 const CACHE_PATH = process.env.TILECACHE_PATH
 
-function get(tileset, z, x, y, cb) {
+/**
+ * Get a tile from the cache
+ *
+ * @param {String} tileset
+ * @param {number} z zoom level
+ * @param {number} x
+ * @param {number} y
+ */
+function get(tileset, z, x, y) {
     if (!should_try_cache(tileset, z)) {
-        cb(`Skip cache get ${tileset}/${z}/${x}/${y}`, null)
-        return
+        return Promise.reject(`Skip cache get ${tileset}/${z}/${x}/${y}`);
     }
-    const dir = `${CACHE_PATH}/${tileset}/${z}/${x}`
-    const fname = `${dir}/${y}.png`
-    fs.readFile(fname, cb)
-}
-
-function put(im, tileset, z, x, y, cb) {
-    if (!should_try_cache(tileset, z)) {
-        cb(`Skip cache put ${tileset}/${z}/${x}/${y}`)
-        return
-    }
-    const dir = `${CACHE_PATH}/${tileset}/${z}/${x}`
-    const fname = `${dir}/${y}.png`
-    fs.writeFile(fname, im, 'binary', (err) => {
-        if (err && err.code === 'ENOENT') {
-            fs.mkdir(dir, 0o755, true, (err) => {
-                if (err) {
-                    cb(err);
-                } else {
-                    fs.writeFile(fname, im, 'binary', cb);
-                }
-            });
-        } else {
-            cb(err)
-        }
+    const location = cache_location(tileset, z, x, y);
+    return new Promise((resolve, reject) => {
+        fs.readFile(location.fname, (err, data) => {
+            if (err) {
+                reject(err)
+            } else {
+                resolve(data)
+            }
+        })
     });
 }
 
+/**
+ * Put a tile in the cache
+ *
+ * @param {Buffer} im image data
+ * @param {String} tileset
+ * @param {number} z zoom level
+ * @param {number} x
+ * @param {number} y
+ */
+function put(im, tileset, z, x, y) {
+    if (!should_try_cache(tileset, z)) {
+        return Promise.reject(`Skip cache put ${tileset}/${z}/${x}/${y}`);
+    }
+    const location = cache_location(tileset, z, x, y);
+    return new Promise((resolve, reject) => {
+        fs.writeFile(location.fname, im, 'binary', (err) => {
+            if (err && err.code === 'ENOENT') {
+                // recursively create tile directory if it didn't previously exist
+                fs.mkdir(location.dir, 0o755, true, (err) => {
+                    if (err) {
+                        reject(err);
+                    } else {
+                        // then write the file
+                        fs.writeFile(location.fname, im, 'binary', (err) => {
+                            (err)? reject(err): resolve()
+                        });
+                    }
+                });
+            } else {
+                (err)? reject(err): resolve()
+            }
+        });
+    })
+}
+
+/**
+ * Remove a single cached tile
+ *
+ * @param {String} tileset
+ * @param {number} z zoom level
+ * @param {number} x
+ * @param {number} y
+ */
+function remove(tileset, z, x, y) {
+    const location = cache_location(tileset, z, x, y)
+    return new Promise(resolve => {
+        fs.unlink(location.fname, (err) => {
+            if(err){
+                // pass
+            } else {
+                console.log("Expire cache", tileset, z, x, y)
+            }
+            resolve()
+        })
+    })
+}
+
+/**
+ * Remove all cached data-visualising tiles which intersect a bbox
+ * - initially called directly after edits; may be better on a worker process?
+ *
+ * @param {String} tileset
+ * @param {Array} bbox [w, s, e, n] in EPSG:3857 coordinates
+ */
+function remove_all_at_bbox(bbox) {
+    // magic numbers for min/max zoom
+    const min_zoom = 9;
+    const max_zoom = 18;
+    // magic list of tilesets - see tileserver, other cache rules
+    const tilesets = ['date_year', 'size_storeys', 'location', 'likes', 'conservation_area'];
+    let tile_bounds;
+    const remove_promises = [];
+    for (let ti = 0; ti < tilesets.length; ti++) {
+        const tileset = tilesets[ti];
+        for (let z = min_zoom; z <= max_zoom; z++) {
+            tile_bounds = get_xyz(bbox, z)
+            for (let x = tile_bounds.minX; x <= tile_bounds.maxX; x++){
+                for (let y = tile_bounds.minY; y <= tile_bounds.maxY; y++){
+                    remove_promises.push(remove(tileset, z, x, y))
+                }
+            }
+        }
+    }
+    Promise.all(remove_promises)
+}
+
+/**
+ * Cache location for a tile
+ *
+ * @param {String} tileset
+ * @param {number} z zoom level
+ * @param {number} x
+ * @param {number} y
+ * @returns {object} { dir: <directory>, fname: <full filepath> }
+ */
+function cache_location(tileset, z, x, y) {
+    const dir = `${CACHE_PATH}/${tileset}/${z}/${x}`
+    const fname = `${dir}/${y}.png`
+    return {dir, fname}
+}
+
+/**
+ * Check rules for caching tiles
+ *
+ * @param {String} tileset
+ * @param {number} z zoom level
+ * @returns {boolean} whether to use the cache (or not)
+ */
 function should_try_cache(tileset, z) {
     if (tileset === 'date_year') {
         // cache high zoom because of front page hits
@@ -65,4 +168,4 @@ function should_try_cache(tileset, z) {
     return z <= 13
 }
 
-export { get, put };
+export { get, put, remove, remove_all_at_bbox };

--- a/app/src/tiles/tile.js
+++ b/app/src/tiles/tile.js
@@ -1,6 +1,14 @@
 /**
  * Render tiles
  *
+ * Use mapnik to render map tiles from the database
+ *
+ * Styles have two sources of truth for colour ranges (could generate from single source?)
+ * - XML style definitions in app/map_styles/polygon.xml
+ * - front-end legend in app/src/frontend/legend.js
+ *
+ * Data is provided by the queries in MAP_STYLE_TABLE_DEFINITIONS below.
+ *
  */
 import path from 'path';
 import mapnik from 'mapnik';

--- a/app/src/tiles/tileserver.js
+++ b/app/src/tiles/tileserver.js
@@ -132,8 +132,8 @@ function outside_extent(z, x, y) {
 function empty_tile() {
     return sharp({
         create: {
-            width: TILE_SIZE,
-            height: TILE_SIZE,
+            width: 1,
+            height: 1,
             channels: 4,
             background: { r: 0, g: 0, b: 0, alpha: 0 }
         }

--- a/app/src/tiles/tileserver.js
+++ b/app/src/tiles/tileserver.js
@@ -209,6 +209,10 @@ function handle_highlight_tile_request(req, res) {
         return
     }
 
+    if (outside_extent(z, x, y)) {
+        return empty_tile()
+    }
+
     render_tile('highlight', int_z, int_x, int_y, geometry_id, function (err, im) {
         if (err) throw err
 

--- a/app/src/tiles/tileserver.js
+++ b/app/src/tiles/tileserver.js
@@ -1,5 +1,8 @@
 /**
- * Tileserver routes for Express app
+ * Tileserver
+ * - routes for Express app
+ * - stitch tiles above a certain zoom level (compositing from sharply-rendered lower zooms)
+ * - render empty tile outside extent of geographical area of interest
  *
  */
 import express from 'express';


### PR DESCRIPTION
Aiming to:
- fix #219 recently-coloured buildings change colour as you zoom out - by removing cached tiles on edit
- close #163 and close #85 cache tiles and aggregate colours as you zoom out

Also reworks `cache` as promise-based (returning promises instead of requiring callbacks to be passed in).