### PR TITLE
Implementation for: Hide or shrink theme switch button on mobile #273

### DIFF
--- a/app/src/frontend/theme-switcher.css
+++ b/app/src/frontend/theme-switcher.css
@@ -21,3 +21,9 @@
     background-image: none;
     border-color: #343a40;
 }
+@media (max-width: 768px){
+    .theme-switcher {
+        visibility: hidden;
+    }
+}
+


### PR DESCRIPTION
Used media request (with `max-width: 768px`) to hide the theme switcher button for small screens. The `max-width` is somewhat arbitrary but easy to change if needs be.