### PR TITLE
Allow custom highlight colour based on data layer

### DIFF
--- a/app/map_styles/polygon.xml
+++ b/app/map_styles/polygon.xml
@@ -35,6 +35,12 @@
     </Style>
     <Style name="highlight">
         <Rule>
+            <Filter>[base_layer] = 'location' or [base_layer] = 'conservation_area'</Filter>
+            <LineSymbolizer stroke="#ff0000aa" stroke-width="4.5" />
+            <LineSymbolizer stroke="#ff0000ff" stroke-width="2.5" />
+        </Rule>
+        <Rule>
+            <ElseFilter />
             <LineSymbolizer stroke="#00ffffaa" stroke-width="4.5" />
             <LineSymbolizer stroke="#00ffffff" stroke-width="2.5" />
         </Rule>

--- a/app/src/frontend/map.tsx
+++ b/app/src/frontend/map.tsx
@@ -123,7 +123,7 @@ class ColouringMap extends Component<any, any> { // TODO: add proper types
 
         // highlight
         const geometryId = (this.props.building) ? this.props.building.geometry_id : undefined;
-        const highlight = `/tiles/highlight/{z}/{x}/{y}.png?highlight=${geometryId}`
+        const highlight = `/tiles/highlight/{z}/{x}/{y}.png?highlight=${geometryId}&base=${tileset}`
         const highlightLayer = (isBuilding && this.props.building) ?
             <TileLayer
                 key={this.props.building.building_id}

--- a/app/src/tiles/tileserver.ts
+++ b/app/src/tiles/tileserver.ts
@@ -99,7 +99,7 @@ function renderOrStitchTile(tileset, z, x, y) {
     } else {
 
         return new Promise((resolve, reject) => {
-            renderTile(tileset, z, x, y, undefined, (err, im) => {
+            renderTile(tileset, z, x, y, {}, (err, im) => {
                 if (err) {
                     reject(err)
                     return
@@ -193,9 +193,9 @@ function handleHighlightTileRequest(req, res) {
     }
 
     // highlight layer uses geometry_id to outline a single building
-    const { highlight } = req.query
+    const { highlight, base } = req.query
     const geometryId = strictParseInt(highlight);
-    if (isNaN(geometryId)) {
+    if (isNaN(geometryId) || ( base != undefined && !base.match(/^\w+$/) )) {
         res.status(400).send({ error: 'Bad parameter' })
         return
     }
@@ -204,7 +204,10 @@ function handleHighlightTileRequest(req, res) {
         return emptyTile()
     }
 
-    renderTile('highlight', intZ, intX, intY, geometryId, function (err, im) {
+    renderTile('highlight', intZ, intX, intY, {
+        geometryId,
+        baseTileset: base
+    }, function (err, im) {
         if (err) {throw err}
 
         res.writeHead(200, { 'Content-Type': 'image/png' })


### PR DESCRIPTION
Resolves #400.
This allows setting custom highlight colour, depending on colour scale of the base data layer.
If no custom colour is present, the highlight will default to original turquoise colour.
Current example displays a contrasting red highlight for `location` and `planning` datasets. Please note that in the style XML file, the `base_layer` filter needs to reference the name of the dataset as it's used in the XML file, not in the frontend. For example, `planning` dataset is actually referenced in the XML as `conservation_area`.

Comments on functionality welcome.