### PR TITLE
Use tile scale cache suffix for scale above 1 only

### DIFF
--- a/app/src/tiles/tileCache.ts
+++ b/app/src/tiles/tileCache.ts
@@ -125,7 +125,8 @@ class TileCache {
 
     private cacheLocation({tileset, z, x, y, scale}: TileParams): CacheLocation {
         const dir = `${this.basePath}/${tileset}/${z}/${x}`;
-        const fname = `${dir}/${y}@${scale}x.png`;
+        const scaleSuffix = scale === 1 ? '' : `@${scale}x`;
+        const fname = `${dir}/${y}${scaleSuffix}.png`;
         return { dir, fname };
     }
 


### PR DESCRIPTION
The tile params formatting is used for caching.
Don't add the @1x suffix for scale 1, in order to
re-use old cache from before retina tiles were enabled