### PR TITLE
Allow zoom level 19 with OS basemap interpolation

### DIFF
--- a/app/src/frontend/map/map.tsx
+++ b/app/src/frontend/map/map.tsx
@@ -112,10 +112,12 @@ class ColouringMap extends Component<ColouringMapProps, ColouringMapState> { // 
         const baseLayer = <TileLayer
             url={baseUrl}
             attribution={attribution}
+            maxNativeZoom={18}
+            maxZoom={19}
         />;
 
         const buildingsBaseUrl = `/tiles/base_${this.state.theme}/{z}/{x}/{y}{r}.png`;
-        const buildingBaseLayer = <TileLayer url={buildingsBaseUrl} minZoom={14} />;
+        const buildingBaseLayer = <TileLayer url={buildingsBaseUrl} minZoom={14} maxZoom={19}/>;
 
         // colour-data tiles
         const cat = this.props.category;
@@ -136,6 +138,7 @@ class ColouringMap extends Component<ColouringMapProps, ColouringMapState> { // 
                 key={tileset}
                 url={`/tiles/${tileset}/{z}/{x}/{y}{r}.png?rev=${rev}`}
                 minZoom={9}
+                maxZoom={19}
             />
             : null;
 
@@ -144,7 +147,8 @@ class ColouringMap extends Component<ColouringMapProps, ColouringMapState> { // 
             <TileLayer
                 key={this.props.building.building_id}
                 url={`/tiles/highlight/{z}/{x}/{y}{r}.png?highlight=${this.props.building.geometry_id}&base=${tileset}`}
-                minZoom={14}
+                minZoom={13}
+                maxZoom={19}
                 zIndex={100}
             />
             : null;
@@ -157,7 +161,7 @@ class ColouringMap extends Component<ColouringMapProps, ColouringMapState> { // 
                     center={position}
                     zoom={this.state.zoom}
                     minZoom={9}
-                    maxZoom={18}
+                    maxZoom={19}
                     doubleClickZoom={false}
                     zoomControl={false}
                     attributionControl={false}

--- a/app/src/tiles/rendererDefinition.ts
+++ b/app/src/tiles/rendererDefinition.ts
@@ -34,7 +34,7 @@ const tileCache = new TileCache(
     {
         tilesets: ['date_year', 'size_storeys', 'location', 'likes', 'conservation_area', 'sust_dec', 'building_attachment_form'],
         minZoom: 9,
-        maxZoom: 18,
+        maxZoom: 19,
         scales: [1, 2]
     },
     ({ tileset, z }: TileParams) => (tileset === 'date_year' && z <= 16) ||


### PR DESCRIPTION
Resolves #72 - if we agree that no one will ever want to zoom in more than to zoom level 19. I haven't seen buildings that would be too small on that level, which would be good because I think we could just get away with displaying the stretched basemap tiles.

One small additional change: show highlight layer also on zoom level 13, because most buildings are still visible at that level.