### PR TITLE
Refactor types and await for user/building backend

### DIFF
--- a/app/src/api/controllers/buildingController.ts
+++ b/app/src/api/controllers/buildingController.ts
@@ -61,20 +61,20 @@ const updateBuildingById = asyncController(async (req: express.Request, res: exp
 
 async function updateBuilding(req: express.Request, res: express.Response, userId: string) {
     const { building_id } = req.params;
-    let building = req.body;
+    const buildingUpdate = req.body;
 
     try {
-        building = await buildingService.saveBuilding(building_id, building, userId);
+        const building = await buildingService.saveBuilding(building_id, buildingUpdate, userId);
 
-        if (building.error) {
-            return res.send(building);
-        }
         if (typeof (building) === 'undefined') {
             return res.send({ error: 'Database error' });
         }
+        if (building.error) {
+            return res.send(building);
+        }
         res.send(building);
     } catch(err) {
-        res.send({ error: 'Database errror' });
+        res.send({ error: 'Database error' });
     }
 }
 

--- a/app/src/api/services/building.ts
+++ b/app/src/api/services/building.ts
@@ -144,7 +144,7 @@ async function saveBuilding(buildingId: number, building: any, userId: string) {
     // - update to latest state
     // commit or rollback (repeated-read sufficient? or serializable?)
     try {
-        await db.tx(async t => {
+        return await db.tx(async t => {
             const oldBuilding = await t.one(
                 'SELECT * FROM buildings WHERE building_id = $1 FOR UPDATE;',
                 [buildingId]
@@ -202,7 +202,7 @@ async function likeBuilding(buildingId: number, userId: string) {
     // - update building to latest state
     // commit or rollback (serializable - could be more compact?)
     try {
-        await db.tx({mode: serializable}, async t => {
+        return await db.tx({mode: serializable}, async t => {
             await t.none(
                 'INSERT INTO building_user_likes ( building_id, user_id ) VALUES ($1, $2);',
                 [buildingId, userId]
@@ -259,7 +259,7 @@ async function unlikeBuilding(buildingId: number, userId: string) {
     // - update building to latest state
     // commit or rollback (serializable - could be more compact?)
     try {
-        await db.tx({mode: serializable}, async t => {
+        return await db.tx({mode: serializable}, async t => {
             await t.none(
                 'DELETE FROM building_user_likes WHERE building_id = $1 AND user_id = $2;',
                 [buildingId, userId]

--- a/app/src/api/services/user.ts
+++ b/app/src/api/services/user.ts
@@ -6,173 +6,185 @@ import { errors } from 'pg-promise';
 
 import db from '../../db';
 import { validateUsername, ValidationError, validatePassword } from '../validation';
+import { promisify } from 'util';
 
-function createUser(user) {
+
+async function createUser(user) {
     try {
         validateUsername(user.username);
         validatePassword(user.password);
     } catch(err) {
         if (err instanceof ValidationError) {
-            return Promise.reject({ error: err.message });
+            throw { error: err.message };
         } else throw err;
     }
     
-    return db.one(
-        `INSERT
-        INTO users (
-            user_id,
-            username,
-            email,
-            pass
-        ) VALUES (
-            gen_random_uuid(),
-            $1,
-            $2,
-            crypt($3, gen_salt('bf'))
-        ) RETURNING user_id
-        `, [
-            user.username,
-            user.email,
-            user.password
-        ]
-    ).catch(function (error) {
-        console.error('Error:', error)
+    try {
+        return await db.one(
+            `INSERT
+            INTO users (
+                user_id,
+                username,
+                email,
+                pass
+            ) VALUES (
+                gen_random_uuid(),
+                $1,
+                $2,
+                crypt($3, gen_salt('bf'))
+            ) RETURNING user_id
+            `, [
+                user.username,
+                user.email,
+                user.password
+            ]
+        );
+    } catch(error) {
+        console.error('Error:', error);
 
-        if (error.detail.indexOf('already exists') !== -1) {
-            if (error.detail.indexOf('username') !== -1) {
+        if (error.detail.includes('already exists')) {
+            if (error.detail.includes('username')) {
                 return { error: 'Username already registered' };
-            } else if (error.detail.indexOf('email') !== -1) {
+            } else if (error.detail.includes('email')) {
                 return { error: 'Email already registered' };
             }
         }
-        return { error: 'Database error' }
-    });
+        return { error: 'Database error' };
+    }
 }
 
-function authUser(username, password) {
-    return db.one(
-        `SELECT
-            user_id,
-            (
-                pass = crypt($2, pass)
-            ) AS auth_ok
-        FROM users
-        WHERE
-        username = $1
-        `, [
-            username,
-            password
-        ]
-    ).then(function (user) {
+async function authUser(username: string, password: string) {
+    try {
+        const user = await db.one(
+            `SELECT
+                user_id,
+                (
+                    pass = crypt($2, pass)
+                ) AS auth_ok
+            FROM users
+            WHERE
+            username = $1
+            `, [
+                username,
+                password
+            ]
+        );
+
         if (user && user.auth_ok) {
             return { user_id: user.user_id }
         } else {
             return { error: 'Username or password not recognised' }
         }
-    }).catch(function (err) {
+    } catch(err) {
         if (err instanceof errors.QueryResultError) {
             console.error(`Authentication failed for user ${username}`);
             return { error: 'Username or password not recognised' };
         }
         console.error('Error:', err);
         return { error: 'Database error' }; 
-    })
+    }
 }
 
-function getUserById(id) {
-    return db.one(
-        `SELECT
-            username, email, registered, api_key
-        FROM
-            users
-        WHERE
-            user_id = $1
-        `, [
-            id
-        ]
-    ).catch(function (error) {
+async function getUserById(id: string) {
+    try {
+        return await db.one(
+            `SELECT
+                username, email, registered, api_key
+            FROM
+                users
+            WHERE
+                user_id = $1
+            `, [
+                id
+            ]
+        );
+    } catch(error) {
         console.error('Error:', error)
         return undefined;
-    });
+    }
 }
 
-function getUserByEmail(email: string) {
-    return db.one(
-        `SELECT
-            user_id, username, email
-        FROM
-            users
-        WHERE
-            email = $1
-        `, [email]
-    ).catch(function(error) {
+async function getUserByEmail(email: string) {
+    try {
+        return db.one(
+            `SELECT
+                user_id, username, email
+            FROM
+                users
+            WHERE
+                email = $1
+            `, [email]
+        );
+    } catch(error) {
         console.error('Error:', error);
         return undefined;
-    });
+    }
 }
 
-function getNewUserAPIKey(id) {
-    return db.one(
-        `UPDATE
-            users
-        SET
-            api_key = gen_random_uuid()
-        WHERE
-            user_id = $1
-        RETURNING
-            api_key
-        `, [
-            id
-        ]
-    ).catch(function (error) {
+async function getNewUserAPIKey(id: string) {
+    try{
+        return db.one(
+            `UPDATE
+                users
+            SET
+                api_key = gen_random_uuid()
+            WHERE
+                user_id = $1
+            RETURNING
+                api_key
+            `, [
+                id
+            ]
+        );
+    } catch(error) {
         console.error('Error:', error)
         return { error: 'Failed to generate new API key.' };
-    });
+    }
 }
 
-function authAPIUser(key) {
-    return db.one(
-        `SELECT
-            user_id
-        FROM
-            users
-        WHERE
-            api_key = $1
-        `, [
-            key
-        ]
-    ).catch(function (error) {
+async function authAPIUser(key: string) {
+    try {
+        return await db.one(
+            `SELECT
+                user_id
+            FROM
+                users
+            WHERE
+                api_key = $1
+            `, [
+                key
+            ]
+        );
+    } catch(error) {
         console.error('Error:', error)
         return undefined;
-    });
+    }
 }
 
-function deleteUser(id) {
-    return db.none(
-        `UPDATE users
-        SET
-            email = null,
-            pass = null,
-            api_key = null,
-            username = concat('deleted_', cast(user_id as char(13))),
-            is_deleted = true,
-            deleted_on = now() at time zone 'utc'
-        WHERE user_id = $1
-        `, [id]
-    ).catch((error) => {
+async function deleteUser(id: string) {
+    try {
+        return await db.none(
+            `UPDATE users
+            SET
+                email = null,
+                pass = null,
+                api_key = null,
+                username = concat('deleted_', cast(user_id as char(13))),
+                is_deleted = true,
+                deleted_on = now() at time zone 'utc'
+            WHERE user_id = $1
+            `, [id]
+        );
+    } catch(error) {
         console.error('Error:', error);
         return {error: 'Database error'};
-    });
+    }
 }
 
-function logout(session: Express.Session) {
-    return new Promise((resolve, reject) => {
-        session.user_id = undefined;
-        session.destroy(err => {
-            if (err) return reject(err);
-            return resolve();
-        });
-    });
+function logout(session: Express.Session): Promise<void> {
+    session.user_id = undefined;
+
+    return promisify(session.destroy.bind(session))();
 }
 
 export {


### PR DESCRIPTION
Refactoring of user and buildings backend service to improve typings, usage of async/await, reducing repetition.

Minor changes to functionality include:
- tx isolation lvl for save/like/unlike building is always serializable
- both reverse and forward patch is being updated for like/unlike (was only forward before)
- comparing old and new data uses == instead of ===
 (this is because the new data even for numbers comes in as string - this can be changed back once the view/edit changes are merged later on)
- the checking of no data change in case of building unlike was fixed
 (hadn't worked because it re-used code for like, which is different)
