### PR TITLE
Feature 84: show edit history

### DIFF
--- a/app/src/api/controllers/buildingController.ts
+++ b/app/src/api/controllers/buildingController.ts
@@ -110,6 +110,17 @@ const getBuildingLikeById = asyncController(async (req: express.Request, res: ex
     }
 });
 
+const getBuildingEditHistoryById = asyncController(async (req: express.Request, res: express.Response) => {
+    const { building_id } = req.params;
+    try {
+        const editHistory = await buildingService.getBuildingEditHistory(building_id);
+
+        res.send({ history: editHistory });
+    } catch(error) {
+        res.send({ error: 'Database error' });
+    }
+});
+
 const updateBuildingLikeById = asyncController(async (req: express.Request, res: express.Response) => {
     if (!req.session.user_id) {
         return res.send({ error: 'Must be logged in' });
@@ -142,5 +153,6 @@ export default {
     updateBuildingById,
     getBuildingUPRNsById,
     getBuildingLikeById,
-    updateBuildingLikeById
+    updateBuildingLikeById,
+    getBuildingEditHistoryById
 };

--- a/app/src/api/routes/buildingsRouter.ts
+++ b/app/src/api/routes/buildingsRouter.ts
@@ -29,4 +29,7 @@ router.route('/:building_id/like.json')
     .get(buildingController.getBuildingLikeById)
     .post(buildingController.updateBuildingLikeById);
 
+router.route('/:building_id/history.json')
+    .get(buildingController.getBuildingEditHistoryById);
+
 export default router;

--- a/app/src/api/services/building.ts
+++ b/app/src/api/services/building.ts
@@ -409,6 +409,7 @@ export {
     queryBuildingsByReference,
     getBuildingById,
     getBuildingLikeById,
+    getBuildingEditHistory,
     getBuildingUPRNsById,
     saveBuilding,
     likeBuilding,

--- a/app/src/api/services/building.ts
+++ b/app/src/api/services/building.ts
@@ -99,7 +99,8 @@ async function getBuildingEditHistory(id: number) {
         return await db.manyOrNone(
             `SELECT log_id as revision_id, forward_patch, reverse_patch, date_trunc('minute', log_timestamp), username
             FROM logs, users
-            WHERE building_id = $1 AND logs.user_id = users.user_id`,
+            WHERE building_id = $1 AND logs.user_id = users.user_id
+            ORDER BY log_timestamp DESC`,
             [id]
         );
     } catch(error) {

--- a/app/src/frontend/app.tsx
+++ b/app/src/frontend/app.tsx
@@ -105,7 +105,7 @@ class App extends React.Component<AppProps, any> { // TODO: add proper types
                 <Route exact path="/data-accuracy.html" component={DataAccuracyPage} />
                 <Route exact path="/data-extracts.html" component={DataExtracts} />
                 <Route exact path="/contact.html" component={ContactPage} />
-                <Route exact path={["/", "/:mode(view|edit|multi-edit)/:category/:building(\\d+)?"]} render={(props) => (
+                <Route exact path={["/", "/:mode(view|edit|multi-edit)/:category?/:building(\\d+)?/(history)?"]} render={(props) => (
                     <MapApp
                         {...props}
                         building={this.props.building}

--- a/app/src/frontend/building/container-header.tsx
+++ b/app/src/frontend/building/container-header.tsx
@@ -3,66 +3,20 @@ import { Link, NavLink } from 'react-router-dom';
 
 import { BackIcon, EditIcon, ViewIcon }from '../components/icons';
 
+interface ContainerHeaderProps {
+    cat?: string;
+    backLink: string;
+    title: string;
+}
 
-const ContainerHeader: React.FunctionComponent<any> = (props) => (
-    <header className={`section-header view ${props.cat} background-${props.cat}`}>
-        <Link className="icon-button back" to={`/${props.mode}/categories${props.building != undefined ? `/${props.building.building_id}` : ''}`}>
+const ContainerHeader: React.FunctionComponent<ContainerHeaderProps> = (props) => (
+    <header className={`section-header view ${props.cat ? props.cat : ''} ${props.cat ? `background-${props.cat}` : ''}`}>
+        <Link className="icon-button back" to={props.backLink}>
             <BackIcon />
         </Link>
         <h2 className="h2">{props.title}</h2>
         <nav className="icon-buttons">
-            {
-                props.building != undefined && !props.inactive ?
-                    props.copy.copying?
-                        <Fragment>
-                            <NavLink
-                                to={`/multi-edit/${props.cat}?data=${props.data_string}`}
-                                className="icon-button copy">
-                                Copy selected
-                            </NavLink>
-                            <a
-                                className="icon-button copy"
-                                onClick={props.copy.toggleCopying}>
-                                Cancel
-                            </a>
-                        </Fragment>
-                    :
-                        <a
-                            className="icon-button copy"
-                            onClick={props.copy.toggleCopying}>
-                            Copy
-                        </a>
-                : null
-            }
-            {
-                props.help && !props.copy.copying?
-                    <a
-                        className="icon-button help"
-                        title="Find out more"
-                        href={props.help}>
-                        Info
-                    </a>
-                : null
-            }
-            {
-                props.building != undefined && !props.inactive && !props.copy.copying?
-                    (props.mode === 'edit')?
-                        <NavLink
-                            className="icon-button view"
-                            title="View data"
-                            to={`/view/${props.cat}/${props.building.building_id}`}>
-                            View
-                            <ViewIcon />
-                        </NavLink>
-                        : <NavLink
-                            className="icon-button edit"
-                            title="Edit data"
-                            to={`/edit/${props.cat}/${props.building.building_id}`}>
-                            Edit
-                            <EditIcon />
-                        </NavLink>
-                : null
-            }
+            {props.children}
         </nav>
     </header>
 )

--- a/app/src/frontend/building/data-components/year-data-entry.tsx
+++ b/app/src/frontend/building/data-components/year-data-entry.tsx
@@ -2,6 +2,7 @@ import React, { Component, Fragment } from 'react';
 import PropTypes from 'prop-types';
 
 import NumericDataEntry from './numeric-data-entry';
+import { dataFields } from '../../data_fields';
 
 class YearDataEntry extends Component<any, any> { // TODO: add proper types
     static propTypes = { // TODO: generate propTypes from TS
@@ -35,7 +36,7 @@ class YearDataEntry extends Component<any, any> { // TODO: add proper types
         return (
             <Fragment>
                 <NumericDataEntry
-                    title="Year built (best estimate)"
+                    title={dataFields.date_year.title}
                     slug="date_year"
                     value={props.year}
                     mode={props.mode}
@@ -44,24 +45,24 @@ class YearDataEntry extends Component<any, any> { // TODO: add proper types
                     // "type": "year_estimator"
                     />
                 <NumericDataEntry
-                    title="Latest possible start year"
+                    title={dataFields.date_upper.title}
                     slug="date_upper"
                     value={props.upper}
                     mode={props.mode}
                     copy={props.copy}
                     onChange={props.onChange}
                     step={1}
-                    tooltip="This should be the latest year in which building could have started."
+                    tooltip={dataFields.date_upper.tooltip}
                     />
                 <NumericDataEntry
-                    title="Earliest possible start date"
+                    title={dataFields.date_lower.title}
                     slug="date_lower"
                     value={props.lower}
                     mode={props.mode}
                     copy={props.copy}
                     onChange={props.onChange}
                     step={1}
-                    tooltip="This should be the earliest year in which building could have started."
+                    tooltip={dataFields.date_lower.tooltip}
                     />
             </Fragment>
         )

--- a/app/src/frontend/building/data-container.tsx
+++ b/app/src/frontend/building/data-container.tsx
@@ -1,10 +1,12 @@
 import React, { Fragment } from 'react';
 import PropTypes from 'prop-types';
-import { Redirect } from 'react-router-dom';
+import { Redirect, NavLink } from 'react-router-dom';
 
 import ContainerHeader from './container-header';
 import ErrorBox from '../components/error-box';
 import InfoBox from '../components/info-box';
+import { CopyControl } from './header-buttons/copy-control';
+import { ViewEditControl } from './header-buttons/view-edit-control';
 
 /**
  * Shared functionality for view/edit forms
@@ -196,15 +198,56 @@ const withCopyEdit = (WrappedComponent) => {
                 toggleCopyAttribute: this.toggleCopyAttribute,
                 copyingKey: (key) => this.state.keys_to_copy[key]
             }
+
+            const headerBackLink = `/${this.props.mode}/categories${this.props.building != undefined ? `/${this.props.building.building_id}` : ''}`;
             return (
                 <section
                     id={this.props.slug}
                     className="data-section">
                 <ContainerHeader
-                    {...this.props}
-                    data_string={data_string}
-                    copy={copy}
-                />
+                    cat={this.props.cat}
+                    backLink={headerBackLink}
+                    title={this.props.title}
+                >
+                {
+                    this.props.help && !copy.copying?
+                        <a
+                            className="icon-button help"
+                            title="Find out more"
+                            href={this.props.help}>
+                            Info
+                        </a>
+                    : null
+                }
+                {
+                    this.props.building != undefined && !this.props.inactive ?
+                        <>
+                            <CopyControl
+                                cat={this.props.cat}
+                                data_string={data_string}
+                                copying={copy.copying}
+                                toggleCopying={copy.toggleCopying}
+                            />
+                            {
+                                !copy.copying ?
+                                <>
+                                    <NavLink
+                                        className="icon-button history"
+                                        to={`/${this.props.mode}/${this.props.cat}/${this.props.building.building_id}/history`}
+                                    >History</NavLink>
+                                    <ViewEditControl
+                                        cat={this.props.cat}
+                                        mode={this.props.mode}
+                                        building={this.props.building}
+                                    />
+                                </>
+                                :
+                                null
+                            }
+                        </>
+                    : null
+                }
+                </ContainerHeader>
                 {
                     this.props.building != undefined ?
                     <form

--- a/app/src/frontend/building/data-containers/age.tsx
+++ b/app/src/frontend/building/data-containers/age.tsx
@@ -6,6 +6,7 @@ import NumericDataEntry from '../data-components/numeric-data-entry';
 import SelectDataEntry from '../data-components/select-data-entry';
 import TextboxDataEntry from '../data-components/textbox-data-entry';
 import YearDataEntry from '../data-components/year-data-entry';
+import { dataFields } from '../../data_fields';
 
 /**
 * Age view/edit section
@@ -21,23 +22,23 @@ const AgeView = (props) => (
             onChange={props.onChange}
             />
         <NumericDataEntry
-            title="Facade year"
+            title={dataFields.facade_year.title}
             slug="facade_year"
             value={props.building.facade_year}
             mode={props.mode}
             copy={props.copy}
             onChange={props.onChange}
             step={1}
-            tooltip="Best estimate"
+            tooltip={dataFields.facade_year.tooltip}
             />
         <SelectDataEntry
-            title="Source of information"
+            title={dataFields.date_source.title}
             slug="date_source"
             value={props.building.date_source}
             mode={props.mode}
             copy={props.copy}
             onChange={props.onChange}
-            tooltip="Source for the main start date"
+            tooltip={dataFields.date_source.tooltip}
             placeholder=""
             options={[
                 "Survey of London",
@@ -53,22 +54,22 @@ const AgeView = (props) => (
             ]}
             />
         <TextboxDataEntry
-            title="Source details"
+            title={dataFields.date_source_detail.title}
             slug="date_source_detail"
             value={props.building.date_source_detail}
             mode={props.mode}
             copy={props.copy}
             onChange={props.onChange}
-            tooltip="References for date source (max 500 characters)"
+            tooltip={dataFields.date_source_detail.tooltip}
             />
         <MultiDataEntry
-            title="Text and Image Links"
+            title={dataFields.date_link.title}
             slug="date_link"
             value={props.building.date_link}
             mode={props.mode}
             copy={props.copy}
             onChange={props.onUpdate}
-            tooltip="URL for age and date reference"
+            tooltip={dataFields.date_link.tooltip}
             placeholder="https://..."
             />
     </Fragment>

--- a/app/src/frontend/building/edit-history/building-edit-summary.css
+++ b/app/src/frontend/building/edit-history/building-edit-summary.css
@@ -1,0 +1,14 @@
+.edit-history-entry {
+    border-bottom: 1px solid black;
+    padding: 1em;
+}
+
+
+.edit-history-timestamp {
+    font-size: 1rem;
+    padding: 0;
+}
+
+.edit-history-username {
+    font-size: 0.9rem;
+}

--- a/app/src/frontend/building/edit-history/building-edit-summary.tsx
+++ b/app/src/frontend/building/edit-history/building-edit-summary.tsx
@@ -1,0 +1,52 @@
+import React from 'react';
+import { EditHistoryEntry } from '../models/edit-history-entry';
+import { arrayToDictionary, parseDate } from '../../helpers';
+import { dataFields } from '../../data_fields';
+import { CategoryEditSummary } from './category-edit-summary';
+
+import './building-edit-summary.css';
+
+interface BuildingEditSummaryProps {
+    historyEntry: EditHistoryEntry
+}
+
+function formatDate(dt: Date) {
+    return dt.toLocaleString(undefined, {
+        weekday: 'short',
+        year: 'numeric',
+        month: 'short',
+        day: 'numeric',
+        hour: '2-digit',
+        minute: '2-digit'
+    });
+}
+
+const BuildingEditSummary: React.FunctionComponent<BuildingEditSummaryProps> = props => {
+    const entriesWithMetadata = Object
+            .entries(props.historyEntry.forward_patch)
+            .map(([key, value]) => {
+                const info = dataFields[key] || {};
+                return {
+                    title: info.title || `Unknown field (${key})`,
+                    category: info.category || 'Unknown category',
+                    value: value,
+                    oldValue: props.historyEntry.reverse_patch && props.historyEntry.reverse_patch[key]
+                };
+            });
+    const entriesByCategory = arrayToDictionary(entriesWithMetadata, x => x.category);
+
+
+    return (
+        <div className="edit-history-entry">
+            <h2 className="edit-history-timestamp">Edited on {formatDate(parseDate(props.historyEntry.date_trunc))}</h2>
+            <h3 className="edit-history-username">By {props.historyEntry.username}</h3>
+            {
+                Object.entries(entriesByCategory).map(([category, fields]) => <CategoryEditSummary category={category} fields={fields} />)
+            }
+        </div>
+    );
+}
+
+export {
+    BuildingEditSummary
+};

--- a/app/src/frontend/building/edit-history/category-edit-summary.css
+++ b/app/src/frontend/building/edit-history/category-edit-summary.css
@@ -1,0 +1,23 @@
+.edit-history-category-summary ul {
+    list-style: none;
+    padding-left: 1em;
+}
+
+.edit-history-category-title {
+    font-size: 1rem;
+}
+
+.edit-history-diff {
+    padding: 0 0.2rem;
+    padding-top:0.15rem;
+    border-radius: 2px;
+}
+.edit-history-diff.old {
+    background-color: #f8d9bc;
+    color: #c24e00;
+    text-decoration: line-through;
+}
+.edit-history-diff.new {
+    background-color: #b6dcff;
+    color: #0064c2;
+}

--- a/app/src/frontend/building/edit-history/category-edit-summary.tsx
+++ b/app/src/frontend/building/edit-history/category-edit-summary.tsx
@@ -1,0 +1,31 @@
+import React from 'react';
+
+import './category-edit-summary.css';
+import { FieldEditSummary } from './field-edit-summary';
+
+interface CategoryEditSummaryProps {
+    category: string;
+    fields: {
+        title: string;
+        value: string;
+        oldValue: string;
+    }[];
+}
+
+const CategoryEditSummary : React.FunctionComponent<CategoryEditSummaryProps> = props => (
+    <div className='edit-history-category-summary'>
+        <h3 className='edit-history-category-title'>{props.category}:</h3>
+        <ul>
+        {
+            props.fields.map(x => 
+                <li key={x.title}>
+                    <FieldEditSummary title={x.title} value={x.value} oldValue={x.oldValue} />
+                </li>)
+        }
+        </ul>
+    </div>
+);
+
+export {
+    CategoryEditSummary
+};

--- a/app/src/frontend/building/edit-history/edit-history.css
+++ b/app/src/frontend/building/edit-history/edit-history.css
@@ -1,0 +1,4 @@
+.edit-history-list {
+    list-style: none;
+    padding-left: 1rem;
+}

--- a/app/src/frontend/building/edit-history/edit-history.tsx
+++ b/app/src/frontend/building/edit-history/edit-history.tsx
@@ -1,0 +1,46 @@
+import React, { useState, useEffect } from 'react';
+import { EditHistoryEntry } from '../models/edit-history-entry';
+import { BuildingEditSummary } from './building-edit-summary';
+
+import './edit-history.css';
+import { Building } from '../../models/building';
+import ContainerHeader from '../container-header';
+
+interface EditHistoryProps {
+    building: Building;
+}
+
+const EditHistory: React.FunctionComponent<EditHistoryProps> = (props) => {
+    const [history, setHistory] = useState<EditHistoryEntry[]>(undefined);
+
+    useEffect(() => {
+        const fetchData = async () => {
+            const res = await fetch(`/api/buildings/${props.building.building_id}/history.json`);
+            const data = await res.json();
+
+            setHistory(data.history);
+        };
+
+        if (props.building != undefined) { // only call fn if there is a building provided
+            fetchData(); // define and call, because effect cannot return anything and an async fn always returns a Promise
+        }
+    }, [props.building]); // only re-run effect on building prop change
+    
+    return (
+        <>
+            <ContainerHeader title="Edit history" backLink='.' />
+
+            <ul className="edit-history-list">
+                {history && history.map(entry => (
+                    <li key={`${entry.revision_id}`} className="edit-history-list-element">
+                        <BuildingEditSummary historyEntry={entry} />
+                    </li>
+                ))}
+            </ul>
+        </>
+    );
+}
+
+export {
+    EditHistory
+};

--- a/app/src/frontend/building/edit-history/field-edit-summary.tsx
+++ b/app/src/frontend/building/edit-history/field-edit-summary.tsx
@@ -1,0 +1,20 @@
+import React from 'react';
+
+interface FieldEditSummaryProps {
+    title: string;
+    value: any;
+    oldValue: any;
+}
+
+const FieldEditSummary: React.FunctionComponent<FieldEditSummaryProps> = props => (
+    <>
+        {props.title}:&nbsp;
+        <code title="Value before edit" className='edit-history-diff old'>{props.oldValue}</code>
+        &nbsp;
+        <code title="Value after edit" className='edit-history-diff new'>{props.value}</code>
+    </>
+);
+
+export {
+    FieldEditSummary
+};

--- a/app/src/frontend/building/header-buttons/copy-control.tsx
+++ b/app/src/frontend/building/header-buttons/copy-control.tsx
@@ -1,0 +1,35 @@
+import React from 'react';
+import { NavLink } from 'react-router-dom';
+
+interface CopyControlProps {
+    cat: string;
+    data_string: string;
+    copying: boolean;
+    toggleCopying: () => void;
+}
+
+const CopyControl: React.FC<CopyControlProps> = props => (
+    props.copying ?
+        <>
+            <NavLink
+                to={`/multi-edit/${props.cat}?data=${props.data_string}`}
+                className="icon-button copy">
+                Copy selected
+            </NavLink>
+            <a
+                className="icon-button copy"
+                onClick={props.toggleCopying}>
+                Cancel
+            </a>
+        </>
+        :
+        <a
+            className="icon-button copy"
+            onClick={props.toggleCopying}>
+            Copy
+        </a>
+);
+
+export {
+    CopyControl
+};

--- a/app/src/frontend/building/header-buttons/view-edit-control.tsx
+++ b/app/src/frontend/building/header-buttons/view-edit-control.tsx
@@ -1,0 +1,32 @@
+import React from 'react';
+import { Building } from '../../models/building';
+import { NavLink } from 'react-router-dom';
+import { ViewIcon, EditIcon } from '../../components/icons';
+
+interface ViewEditControlProps {
+    cat: string;
+    mode: 'view' | 'edit';
+    building: Building;
+}
+
+const ViewEditControl: React.FC<ViewEditControlProps> = props => (
+    (props.mode === 'edit')?
+                        <NavLink
+                            className="icon-button view"
+                            title="View data"
+                            to={`/view/${props.cat}/${props.building.building_id}`}>
+                            View
+                            <ViewIcon />
+                        </NavLink>
+                        : <NavLink
+                            className="icon-button edit"
+                            title="Edit data"
+                            to={`/edit/${props.cat}/${props.building.building_id}`}>
+                            Edit
+                            <EditIcon />
+                        </NavLink>
+);
+
+export {
+    ViewEditControl
+};

--- a/app/src/frontend/building/models/edit-history-entry.ts
+++ b/app/src/frontend/building/models/edit-history-entry.ts
@@ -1,0 +1,7 @@
+export interface EditHistoryEntry {
+    date_trunc: string;
+    username: string;
+    revision_id: string;
+    forward_patch: object;
+    reverse_patch: object;
+}

--- a/app/src/frontend/building/sidebar.css
+++ b/app/src/frontend/building/sidebar.css
@@ -9,13 +9,6 @@
     height: 40%;
 }
 
-.info-container h2:first-child {
-    margin-bottom: 0.5rem;
-    margin-top: 0.5rem;
-    margin-left: -0.1em;
-    padding: 0 0.75rem;
-}
-
 @media (min-width: 768px){
     .info-container {
         order: 0;
@@ -99,7 +92,8 @@
     color: rgb(11, 225, 225);
 }
 .icon-button.help,
-.icon-button.copy {
+.icon-button.copy,
+.icon-button.history {
     margin-top: 4px;
 }
 .data-section label .icon-buttons .icon-button.copy {

--- a/app/src/frontend/data_fields.ts
+++ b/app/src/frontend/data_fields.ts
@@ -1,0 +1,72 @@
+export enum Category {
+    Location = 'Location',
+    LandUse = 'Land Use',
+    Type = 'Type',
+    Age = 'Age',
+    SizeShape = 'Size & Shape',
+    Construction = 'Construction',
+    Streetscape = 'Streetscape',
+    Team = 'Team',
+    Sustainability = 'Sustainability',
+    Community = 'Community',
+    Planning = 'Planning',
+    Like = 'Like Me!'
+}
+
+export const categoriesOrder: Category[] = [
+    Category.Location,
+    Category.LandUse,
+    Category.Type,
+    Category.Age,
+    Category.SizeShape,
+    Category.Construction,
+    Category.Streetscape,
+    Category.Team,
+    Category.Sustainability,
+    Category.Community,
+    Category.Planning,
+    Category.Like,
+];
+
+export const dataFields = {
+    date_year: {
+        category: Category.Age,
+        title: "Year built (best estimate)"
+    },
+    date_lower : {
+        category: Category.Age,
+        title: "Earliest possible start date",
+        tooltip: "This should be the earliest year in which building could have started."
+    },
+    date_upper: {
+        category: Category.Age,
+        title: "Latest possible start year",
+        tooltip: "This should be the latest year in which building could have started."
+    },
+    facade_year: {
+        category: Category.Age,
+        title: "Facade year",
+        tooltip: "Best estimate"
+    },
+    date_source: {
+        category: Category.Age,
+        title: "Source of information",
+        tooltip: "Source for the main start date"
+    },
+    date_source_detail: {
+        category: Category.Age,
+        title: "Source details",
+        tooltip: "References for date source (max 500 characters)"
+    },
+    date_link: {
+        category: Category.Age,
+        title: "Text and Image Links",
+        tooltip: "URL for age and date reference",
+    },
+
+    likes_total: {
+        category: Category.Like,
+        title: "Total number of likes"
+    }
+
+};

--- a/app/src/frontend/helpers.ts
+++ b/app/src/frontend/helpers.ts
@@ -36,4 +36,27 @@ function sanitiseURL(string){
   return `${url_.protocol}//${url_.hostname}${url_.pathname || ''}${url_.search || ''}${url_.hash || ''}`
 }
 
-export { sanitiseURL }
+function arrayToDictionary<T>(arr: T[], keyAccessor: (obj: T) => string): {[key: string]: T[]} {
+    return arr.reduce((obj, item) => {
+        (obj[keyAccessor(item)] = obj[keyAccessor(item)] || []).push(item);
+        return obj;
+    }, {});
+}
+
+/**
+ * Parse a string containing 
+ * @param isoUtcDate a date string in ISO8601 format
+ * 
+ */
+function parseDate(isoUtcDate: string): Date {
+    const [year, month, day, hour, minute, second, millisecond] = isoUtcDate.match(/^(\d{4})-(\d\d)-(\d\d)T(\d\d):(\d\d):(\d\d).(\d{3})Z$/)
+        .splice(1)
+        .map(x => parseInt(x, 10));
+    return new Date(Date.UTC(year, month-1, day, hour, minute, second, millisecond));
+}
+
+export {
+    sanitiseURL,
+    arrayToDictionary,
+    parseDate
+};

--- a/app/src/frontend/map-app.tsx
+++ b/app/src/frontend/map-app.tsx
@@ -9,6 +9,8 @@ import MultiEdit from './building/multi-edit';
 import BuildingView from './building/building-view';
 import ColouringMap from './map/map';
 import { parse } from 'query-string';
+import { EditHistory } from './building/edit-history/edit-history';
+import { Building } from './models/building';
 
 interface MapAppRouteParams {
     mode: 'view' | 'edit' | 'multi-edit';
@@ -25,7 +27,7 @@ interface MapAppProps extends RouteComponentProps<MapAppRouteParams> {
 interface MapAppState {
     category: string;
     revision_id: number;
-    building: any;
+    building: Building;
     building_like: boolean;
 }
 
@@ -232,6 +234,11 @@ class MapApp extends React.Component<MapAppProps, MapAppState> {
                                 selectBuilding={this.selectBuilding}
                                 user={this.props.user}
                             />
+                        </Sidebar>
+                    </Route>
+                    <Route exact path="/:mode/:cat/:building/history">
+                        <Sidebar>
+                            <EditHistory building={this.state.building} />
                         </Sidebar>
                     </Route>
                     <Route exact path="/(view|edit|multi-edit)">

--- a/app/src/frontend/models/building.ts
+++ b/app/src/frontend/models/building.ts
@@ -1,0 +1,7 @@
+interface Building {
+    building_id: number;
+}
+
+export {
+    Building
+};

--- a/app/src/parse.ts
+++ b/app/src/parse.ts
@@ -23,7 +23,7 @@ function strictParseInt(value) {
  * @returns {number|undefined}
  */
 function parseBuildingURL(url) {
-    const re = /\/(\d+)$/;
+    const re = /\/(\d+)(\/history)?$/;
     const matches = re.exec(url);
 
     if (matches && matches.length >= 2) {


### PR DESCRIPTION
WIP for feature #84 

The general functionality for edit history is already implemented. Any comments on style / functionality / UI welcome.

Leftover issues:
- there is now one more button in the sidebar header and it gets a bit crowded for categories with long titles
- only Age and Like Me categories have had their descriptions moved to the new `src/frontend/data_fields.ts` file. Need to move the others.