### PR TITLE
Add data accuracy text to welcome screen

### DIFF
--- a/app/src/frontend/pages/welcome.css
+++ b/app/src/frontend/pages/welcome.css
@@ -6,12 +6,14 @@
     z-index: 10000;
     top: 0;
     width: 100%;
-    max-height: 100%;
+    max-height: 95%;
+    max-height: calc(100%-2em);
     border-radius: 0;
-    padding: 1.5em 2.5em 2.5em;
     overflow-y: auto;
 }
+
 .welcome-float.jumbotron {
+    padding: 1em 2.5em 1.5em;
     background: #fff;
     background-color: rgba(255,255,255,0.95);
 }
@@ -22,4 +24,8 @@
         width: 45em;
         top: 1em;
     }
+}
+
+.welcome-float .lead {
+    font-size: 1.15em;
 }

--- a/app/src/frontend/pages/welcome.css
+++ b/app/src/frontend/pages/welcome.css
@@ -29,3 +29,8 @@
 .welcome-float .lead {
     font-size: 1.15em;
 }
+
+.welcome-float .lead a {
+    color: #333;
+    border-bottom-color: #333;
+}

--- a/app/src/frontend/pages/welcome.css
+++ b/app/src/frontend/pages/welcome.css
@@ -27,7 +27,7 @@
 }
 
 .welcome-float .lead {
-    font-size: 1.15em;
+    font-size: 1.2em;
 }
 
 .welcome-float .lead a {

--- a/app/src/frontend/pages/welcome.tsx
+++ b/app/src/frontend/pages/welcome.tsx
@@ -9,14 +9,13 @@ const Welcome = () => (
 
         <p className="lead">
         Colouring London is a knowledge exchange platform collecting information on every
-        building in London, to help make the city more sustainable. We&rsquo;re building it at The
-        Bartlett Centre for Advanced Spatial Analysis, University College London. We're still at an early stage of development. Please help us by providing feedback on the site as we create it.
+        building in London, to help make the city more sustainable. We're developing it at University College London. Can you help us? We're looking for volunteers of all ages and abilities to help test the site and colour the buildings in.
         </p>
         <p className="lead">
-            We collect our building data from many sources. Though we are unable to vouch for their accuracy, we are currently experimenting with a range of features including 'data source', 'edit history', and 'entry verification', to assist you in checking reliability and judging how suitable the data are for your intended use.
+            Our building data comes from many different sources. Though we are unable to vouch for their accuracy, we are currently experimenting with a range of features including 'data source', 'edit history', and 'entry verification', to assist you in checking reliability and judging how suitable the data are for your intended use.
         </p>
         <p className="lead">
-        All of the data we collect is made <Link to="/data-extracts.html">openly available</Link>. We just ask you to credit Colouring London and read our <a href="https://www.pages.colouring.london/data-ethics">data ethics policy</a>  when using or sharing our data and maps.
+            All data we collect are made <Link to="/data-extracts.html">openly available</Link>. We just ask you to credit Colouring London and read our <a href="https://www.pages.colouring.london/data-ethics">data ethics policy</a>  when using or sharing our data, maps or <a href="https://github.com/tomalrussell/colouring-london">code</a>.
         </p>
         <Link to="/view/categories"
             className="btn btn-outline-dark btn-lg btn-block">

--- a/app/src/frontend/pages/welcome.tsx
+++ b/app/src/frontend/pages/welcome.tsx
@@ -22,6 +22,9 @@ const Welcome = () => (
         please read our <a href="https://www.pages.colouring.london/data-ethics">data ethics policy</a> and
         credit Colouring London if you use or share our maps or data.
         </p>
+        <p className="lead">
+            We collect our building data from many sources. Though we are unable to vouch for their accuracy, we are currently experimenting with a range of features including 'data source', 'edit history', and 'entry verification', to assist you in checking reliability and judging how suitable the data are for your intended use.
+        </p>
         <Link to="/view/categories"
             className="btn btn-outline-dark btn-lg btn-block">
             Start Colouring Here!

--- a/app/src/frontend/pages/welcome.tsx
+++ b/app/src/frontend/pages/welcome.tsx
@@ -10,20 +10,13 @@ const Welcome = () => (
         <p className="lead">
         Colouring London is a knowledge exchange platform collecting information on every
         building in London, to help make the city more sustainable. We&rsquo;re building it at The
-        Bartlett Centre for Advanced Spatial Analysis, University College London.
-        </p>
-        <p className="lead">
-        Can you help us? We&rsquo;re still at an early stage of development, and we&rsquo;re looking for
-        volunteers of all ages and abilities to test and provide feedback on the site as we
-        build it.
-        </p>
-        <p className="lead">
-        All of the data we collect is made <Link to="/data-extracts.html">openly available</Link> &ndash;
-        please read our <a href="https://www.pages.colouring.london/data-ethics">data ethics policy</a> and
-        credit Colouring London if you use or share our maps or data.
+        Bartlett Centre for Advanced Spatial Analysis, University College London. We're still at an early stage of development. Please help us by providing feedback on the site as we create it.
         </p>
         <p className="lead">
             We collect our building data from many sources. Though we are unable to vouch for their accuracy, we are currently experimenting with a range of features including 'data source', 'edit history', and 'entry verification', to assist you in checking reliability and judging how suitable the data are for your intended use.
+        </p>
+        <p className="lead">
+        All of the data we collect is made <Link to="/data-extracts.html">openly available</Link>. We just ask you to credit Colouring London and read our <a href="https://www.pages.colouring.london/data-ethics">data ethics policy</a>  when using or sharing our data and maps.
         </p>
         <Link to="/view/categories"
             className="btn btn-outline-dark btn-lg btn-block">


### PR DESCRIPTION
Needed to re-style the welcome page a bit, e.g. decrease the font size, so that the increased amount of text fits fully on most screens. If it still doesn't there will be a scroll-bar that might result in the logos and/or "Start colouring" button being hidden at first, which is not ideal.
See screenshot for current look:
![image](https://user-images.githubusercontent.com/36160844/68765642-8f868f00-061d-11ea-8bdc-eff2c21f9184.png)