### PR TITLE
Fix style issues caused by wrong css import order

### DIFF
--- a/app/src/frontend/app.tsx
+++ b/app/src/frontend/app.tsx
@@ -1,7 +1,7 @@
 import React, { Fragment } from 'react';
 import { Link, Route, Switch } from 'react-router-dom';
 
-import '../../node_modules/bootstrap/dist/css/bootstrap.min.css';
+import 'bootstrap/dist/css/bootstrap.min.css';
 import './app.css';
 
 import Header from './header';

--- a/app/src/frontend/app.tsx
+++ b/app/src/frontend/app.tsx
@@ -1,6 +1,9 @@
 import React, { Fragment } from 'react';
 import { Link, Route, Switch } from 'react-router-dom';
 
+import '../../node_modules/bootstrap/dist/css/bootstrap.min.css';
+import './app.css';
+
 import Header from './header';
 import MapApp from './map-app';
 import { Building } from './models/building';
@@ -18,9 +21,6 @@ import Login from './user/login';
 import MyAccountPage from './user/my-account';
 import PasswordReset from './user/password-reset';
 import SignUp from './user/signup';
-
-import '../../node_modules/bootstrap/dist/css/bootstrap.min.css';
-import './app.css';
 
 
 interface AppProps {

--- a/app/src/frontend/building/data-components/data-entry-group.tsx
+++ b/app/src/frontend/building/data-components/data-entry-group.tsx
@@ -1,8 +1,8 @@
 import React, { Fragment, useState } from "react";
 
-import { DownIcon, RightIcon } from "../../components/icons";
-
 import './data-entry-group.css';
+
+import { DownIcon, RightIcon } from "../../components/icons";
 
 interface DataEntryGroupProps {
     /** Name of the group */

--- a/app/src/frontend/building/edit-history/building-edit-summary.tsx
+++ b/app/src/frontend/building/edit-history/building-edit-summary.tsx
@@ -1,12 +1,12 @@
 import React from 'react';
 
+import './building-edit-summary.css';
+
 import { dataFields } from '../../data_fields';
 import { arrayToDictionary, parseDate } from '../../helpers';
 import { EditHistoryEntry } from '../../models/edit-history-entry';
 
 import { CategoryEditSummary } from './category-edit-summary';
-
-import './building-edit-summary.css';
 
 interface BuildingEditSummaryProps {
     historyEntry: EditHistoryEntry;

--- a/app/src/frontend/building/edit-history/category-edit-summary.tsx
+++ b/app/src/frontend/building/edit-history/category-edit-summary.tsx
@@ -1,8 +1,8 @@
 import React from 'react';
 
-import { FieldEditSummary } from './field-edit-summary';
-
 import './category-edit-summary.css';
+
+import { FieldEditSummary } from './field-edit-summary';
 
 interface CategoryEditSummaryProps {
     category: string;

--- a/app/src/frontend/building/edit-history/edit-history.tsx
+++ b/app/src/frontend/building/edit-history/edit-history.tsx
@@ -1,12 +1,12 @@
 import React, { useEffect, useState } from 'react';
 
+import './edit-history.css';
+
 import { Building } from '../../models/building';
 import { EditHistoryEntry } from '../../models/edit-history-entry';
 import ContainerHeader from '../container-header';
 
 import { BuildingEditSummary } from './building-edit-summary';
-
-import './edit-history.css';
 
 interface EditHistoryProps {
     building: Building;

--- a/app/src/frontend/components/tooltip.tsx
+++ b/app/src/frontend/components/tooltip.tsx
@@ -1,8 +1,8 @@
 import React, { Component } from 'react';
 
-import { InfoIcon } from './icons';
-
 import './tooltip.css';
+
+import { InfoIcon } from './icons';
 
 interface TooltipProps {
     text: string;

--- a/app/src/frontend/header.tsx
+++ b/app/src/frontend/header.tsx
@@ -1,10 +1,10 @@
 import React, { Fragment } from 'react';
 import { NavLink } from 'react-router-dom';
 
+import './header.css';
+
 import { Logo } from './components/logo';
 import { User } from './models/user';
-
-import './header.css';
 
 
 interface HeaderProps {

--- a/app/src/frontend/map/legend.tsx
+++ b/app/src/frontend/map/legend.tsx
@@ -1,9 +1,9 @@
 import React from 'react';
 
+import './legend.css';
+
 import { DownIcon, UpIcon } from '../components/icons';
 import { Logo } from '../components/logo';
-
-import './legend.css';
 
 const LEGEND_CONFIG = {
     location: {

--- a/app/src/frontend/map/map.tsx
+++ b/app/src/frontend/map/map.tsx
@@ -2,15 +2,15 @@ import { GeoJsonObject } from 'geojson';
 import React, { Component, Fragment } from 'react';
 import { AttributionControl, GeoJSON, Map, TileLayer, ZoomControl } from 'react-leaflet-universal';
 
+import '../../../node_modules/leaflet/dist/leaflet.css';
+import './map.css';
+
 import { HelpIcon } from '../components/icons';
 import { Building } from '../models/building';
 
 import Legend from './legend';
 import SearchBox from './search-box';
 import ThemeSwitcher from './theme-switcher';
-
-import '../../../node_modules/leaflet/dist/leaflet.css';
-import './map.css';
 
 const OS_API_KEY = 'NVUxtY5r8eA6eIfwrPTAGKrAAsoeI9E9';
 

--- a/app/src/frontend/map/map.tsx
+++ b/app/src/frontend/map/map.tsx
@@ -2,7 +2,7 @@ import { GeoJsonObject } from 'geojson';
 import React, { Component, Fragment } from 'react';
 import { AttributionControl, GeoJSON, Map, TileLayer, ZoomControl } from 'react-leaflet-universal';
 
-import '../../../node_modules/leaflet/dist/leaflet.css';
+import 'leaflet/dist/leaflet.css';
 import './map.css';
 
 import { HelpIcon } from '../components/icons';

--- a/app/src/frontend/map/search-box.tsx
+++ b/app/src/frontend/map/search-box.tsx
@@ -1,9 +1,9 @@
 import { Point } from 'geojson';
 import React, { Component } from 'react';
 
-import { SearchIcon } from '../components/icons';
-
 import './search-box.css';
+
+import { SearchIcon } from '../components/icons';
 
 interface SearchResult {
     type: string;

--- a/app/src/frontend/pages/about.tsx
+++ b/app/src/frontend/pages/about.tsx
@@ -1,9 +1,9 @@
 import React from 'react';
 
+import './about.css';
+
 import Categories from '../building/categories';
 import SupporterLogos from '../components/supporter-logos';
-
-import './about.css';
 
 const AboutPage = () => (
     <article>

--- a/app/tslint.json
+++ b/app/tslint.json
@@ -7,7 +7,7 @@
       {
         "grouped-imports": true,
         "groups": [
-            { "name": "css", "match": "\\.css$", "order": 40 },
+            { "name": "css", "match": "\\.css$", "order": 15 },
             { "name": "parent directories", "match": "^\\.\\.", "order": 20 },
             { "name": "current directory", "match": "^\\.", "order": 30 },
             { "name": "libraries", "match": ".*", "order": 10 }


### PR DESCRIPTION
A recent change (#497) introduced a bug where the CSS imports were automatically reordered to be the last import group. However, that introduced a bug in styling, because the React components were now imported first (and with them, their CSS rules), and only then the higher level CSS rules. The higher level rules would then override the sub-component rules because of wrong CSS rule ordering.

The solution was to modify the TSLint rules so that the import groups are always in the following order: library imports, CSS imports, imports from other project directories (including components), imports from current project directory (including components).

The import paths for library CSS were also changed to not reference the `node_modules` folder with a relative path - because Webpack's `css-loader` can resolve names of npm-installed packages - so
 ```
import '../../node_modules/bootstrap/dist/css/bootstrap.min.css';
```
 becomes 
```
import 'bootstrap/dist/css/bootstrap.min.css';
```