### PR TITLE
Global edit history

### DIFF
--- a/app/src/api/api.ts
+++ b/app/src/api/api.ts
@@ -1,6 +1,7 @@
 import bodyParser from 'body-parser';
 import express from 'express';
 
+import * as editHistoryController from './controllers/editHistoryController';
 import buildingsRouter from './routes/buildingsRouter';
 import extractsRouter from './routes/extractsRouter';
 import usersRouter from './routes/usersRouter';
@@ -16,6 +17,8 @@ server.use(bodyParser.json());
 server.use('/buildings', buildingsRouter);
 server.use('/users', usersRouter);
 server.use('/extracts', extractsRouter);
+
+server.get('/history', editHistoryController.getGlobalEditHistory);
 
 // POST user auth
 server.post('/login', function (req, res) {

--- a/app/src/api/controllers/editHistoryController.ts
+++ b/app/src/api/controllers/editHistoryController.ts
@@ -6,7 +6,9 @@ import * as editHistoryService from '../services/editHistory';
 const getGlobalEditHistory = asyncController(async (req: express.Request, res: express.Response) => {
     try {
         const result = await editHistoryService.getGlobalEditHistory();
-        res.send(result);
+        res.send({
+            history: result
+        });
     } catch(error) {
         console.error(error);
         res.send({ error: 'Database error' });

--- a/app/src/api/controllers/editHistoryController.ts
+++ b/app/src/api/controllers/editHistoryController.ts
@@ -1,0 +1,18 @@
+import express from 'express';
+
+import asyncController from "../routes/asyncController";
+import * as editHistoryService from '../services/editHistory';
+
+const getGlobalEditHistory = asyncController(async (req: express.Request, res: express.Response) => {
+    try {
+        const result = await editHistoryService.getGlobalEditHistory();
+        res.send(result);
+    } catch(error) {
+        console.error(error);
+        res.send({ error: 'Database error' });
+    }
+});
+
+export {
+    getGlobalEditHistory
+};

--- a/app/src/api/services/editHistory.ts
+++ b/app/src/api/services/editHistory.ts
@@ -1,0 +1,21 @@
+import db from '../../db';
+
+async function getGlobalEditHistory() {
+    try {
+        return await db.manyOrNone(
+            `SELECT log_id as revision_id, forward_patch, reverse_patch, date_trunc('minute', log_timestamp), username, building_id
+            FROM logs, users
+            WHERE logs.user_id = users.user_id
+                AND log_timestamp >= now() - interval '21 days'
+            ORDER BY log_timestamp DESC`
+        );
+    } catch (error) {
+        console.error(error);
+        return [];
+    }
+}
+
+
+export {
+    getGlobalEditHistory
+};

--- a/app/src/frontend/app.tsx
+++ b/app/src/frontend/app.tsx
@@ -9,6 +9,7 @@ import MapApp from './map-app';
 import { Building } from './models/building';
 import { User } from './models/user';
 import AboutPage from './pages/about';
+import ChangesPage from './pages/changes';
 import ContactPage from './pages/contact';
 import ContributorAgreementPage from './pages/contributor-agreement';
 import DataAccuracyPage from './pages/data-accuracy';
@@ -112,6 +113,7 @@ class App extends React.Component<AppProps, AppState> {
                 <Route exact path="/data-accuracy.html" component={DataAccuracyPage} />
                 <Route exact path="/data-extracts.html" component={DataExtracts} />
                 <Route exact path="/contact.html" component={ContactPage} />
+                <Route exact path="/history.html" component={ChangesPage} />
                 <Route exact path={App.mapAppPaths} render={(props) => (
                     <MapApp
                         {...props}

--- a/app/src/frontend/building/edit-history/building-edit-summary.css
+++ b/app/src/frontend/building/edit-history/building-edit-summary.css
@@ -12,3 +12,7 @@
 .edit-history-username {
     font-size: 0.9em;
 }
+
+.edit-history-building-id {
+    font-size: 0.9em;
+}

--- a/app/src/frontend/building/edit-history/building-edit-summary.tsx
+++ b/app/src/frontend/building/edit-history/building-edit-summary.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import { Link } from 'react-router-dom';
 
 import './building-edit-summary.css';
 
@@ -10,6 +11,8 @@ import { CategoryEditSummary } from './category-edit-summary';
 
 interface BuildingEditSummaryProps {
     historyEntry: EditHistoryEntry;
+    showBuildingId?: boolean;
+    hyperlinkCategories?: boolean;
 }
 
 function formatDate(dt: Date) {
@@ -23,27 +26,47 @@ function formatDate(dt: Date) {
     });
 }
 
-const BuildingEditSummary: React.FunctionComponent<BuildingEditSummaryProps> = props => {
+const BuildingEditSummary: React.FunctionComponent<BuildingEditSummaryProps> = ({
+    historyEntry,
+    showBuildingId = false,
+    hyperlinkCategories = false
+}) => {
     const entriesWithMetadata = Object
-            .entries(props.historyEntry.forward_patch)
+            .entries(historyEntry.forward_patch)
             .map(([key, value]) => {
                 const info = dataFields[key] || {};
                 return {
                     title: info.title || `Unknown field (${key})`,
-                    category: info.category || 'Unknown category',
+                    category: info.category || 'Unknown',
                     value: value,
-                    oldValue: props.historyEntry.reverse_patch && props.historyEntry.reverse_patch[key]
+                    oldValue: historyEntry.reverse_patch && historyEntry.reverse_patch[key]
                 };
             });
     const entriesByCategory = arrayToDictionary(entriesWithMetadata, x => x.category);
 
+    const categoryHyperlinkTemplate = hyperlinkCategories && historyEntry.building_id != undefined ?
+            `/edit/$category/${historyEntry.building_id}` :
+            undefined;
 
     return (
         <div className="edit-history-entry">
-            <h2 className="edit-history-timestamp">Edited on {formatDate(parseDate(props.historyEntry.date_trunc))}</h2>
-            <h3 className="edit-history-username">By {props.historyEntry.username}</h3>
+            <h2 className="edit-history-timestamp">Edited on {formatDate(parseDate(historyEntry.date_trunc))}</h2>
+            <h3 className="edit-history-username">By {historyEntry.username}</h3>
             {
-                Object.entries(entriesByCategory).map(([category, fields]) => <CategoryEditSummary category={category} fields={fields} />)
+                showBuildingId && historyEntry.building_id != undefined &&
+                <h3 className="edit-history-building-id">
+                    Building <Link to={`/edit/categories/${historyEntry.building_id}`}>{historyEntry.building_id}</Link>
+                </h3>
+            }
+            {
+                Object.entries(entriesByCategory).map(([category, fields]) => 
+                    <CategoryEditSummary
+                        category={category}
+                        fields={fields}
+                        hyperlinkCategory={hyperlinkCategories}
+                        hyperlinkTemplate={categoryHyperlinkTemplate}
+                    />
+                )
             }
         </div>
     );

--- a/app/src/frontend/building/edit-history/building-edit-summary.tsx
+++ b/app/src/frontend/building/edit-history/building-edit-summary.tsx
@@ -30,7 +30,7 @@ function enrichHistoryEntries(forwardPatch: object, reversePatch: object) {
     return Object
         .entries(forwardPatch)
         .map(([key, value]) => {
-            const info = dataFields[key] as DataFieldDefinition;
+            const info = dataFields[key] || {} as DataFieldDefinition;
             return {
                 title: info.title || `Unknown field (${key})`,
                 category: info.category || Category.Unknown,

--- a/app/src/frontend/building/edit-history/category-edit-summary.tsx
+++ b/app/src/frontend/building/edit-history/category-edit-summary.tsx
@@ -1,6 +1,9 @@
 import React from 'react';
+import { Link } from 'react-router-dom';
 
 import './category-edit-summary.css';
+
+import { categories, Category } from '../../data_fields';
 
 import { FieldEditSummary } from './field-edit-summary';
 
@@ -8,24 +11,41 @@ interface CategoryEditSummaryProps {
     category: string;
     fields: {
         title: string;
-        value: string;
-        oldValue: string;
+        value: any;
+        oldValue: any;
     }[];
+    hyperlinkCategory: boolean;
+    hyperlinkTemplate?: string;
 }
 
-const CategoryEditSummary : React.FunctionComponent<CategoryEditSummaryProps> = props => (
-    <div className='edit-history-category-summary'>
-        <h3 className='edit-history-category-title'>{props.category}:</h3>
-        <ul>
-        {
-            props.fields.map(x => 
-                <li key={x.title}>
-                    <FieldEditSummary title={x.title} value={x.value} oldValue={x.oldValue} />
-                </li>)
-        }
-        </ul>
-    </div>
-);
+const CategoryEditSummary : React.FunctionComponent<CategoryEditSummaryProps> = props => {
+    const category: Category = Category[props.category];
+    console.log(category);
+    console.log(typeof(category));
+    const categoryInfo = categories[category] || {name: undefined, slug: undefined};
+    const categoryName = categoryInfo.name || 'Unknown category';
+    const categorySlug = categoryInfo.slug || 'categories';
+
+    return (
+        <div className='edit-history-category-summary'>
+            <h3 className='edit-history-category-title'>
+                {
+                    props.hyperlinkCategory && props.hyperlinkTemplate != undefined ?
+                        <Link to={props.hyperlinkTemplate.replace(/\$category/, categorySlug)}>{categoryName}</Link> :
+                        categoryName
+                }:
+            </h3>
+            <ul>
+            {
+                props.fields.map(x => 
+                    <li key={x.title}>
+                        <FieldEditSummary title={x.title} value={x.value} oldValue={x.oldValue} />
+                    </li>)
+            }
+            </ul>
+        </div>
+    );
+};
 
 export {
     CategoryEditSummary

--- a/app/src/frontend/building/edit-history/category-edit-summary.tsx
+++ b/app/src/frontend/building/edit-history/category-edit-summary.tsx
@@ -8,7 +8,7 @@ import { categories, Category } from '../../data_fields';
 import { FieldEditSummary } from './field-edit-summary';
 
 interface CategoryEditSummaryProps {
-    category: string;
+    category: keyof typeof Category; // https://github.com/microsoft/TypeScript/issues/14106
     fields: {
         title: string;
         value: any;
@@ -19,9 +19,7 @@ interface CategoryEditSummaryProps {
 }
 
 const CategoryEditSummary : React.FunctionComponent<CategoryEditSummaryProps> = props => {
-    const category: Category = Category[props.category];
-    console.log(category);
-    console.log(typeof(category));
+    const category = Category[props.category];
     const categoryInfo = categories[category] || {name: undefined, slug: undefined};
     const categoryName = categoryInfo.name || 'Unknown category';
     const categorySlug = categoryInfo.slug || 'categories';

--- a/app/src/frontend/data_fields.ts
+++ b/app/src/frontend/data_fields.ts
@@ -11,6 +11,8 @@ export enum Category {
     Community = 'Community',
     Planning = 'Planning',
     Like = 'Like',
+
+    Unknown = 'Unknown'
 }
 
 export const categories = {
@@ -78,6 +80,18 @@ export const categoriesOrder: Category[] = [
     Category.Planning,
     Category.Like,
 ];
+
+/**
+ * This interface is used only in code which uses dataFields, not in the dataFields definition itself
+ * Cannot make dataFields an indexed type ({[key: string]: DataFieldDefinition}),
+ * because then we wouldn't have type-checking for whether a given key exists on dataFields,
+ * e.g. dataFields.foo_bar would not be highlighted as an error.
+ */
+export interface DataFieldDefinition {
+    category: Category;
+    title: string;
+    tooltip?: string;
+}
 
 export const dataFields = {
     location_name: {

--- a/app/src/frontend/data_fields.ts
+++ b/app/src/frontend/data_fields.ts
@@ -1,17 +1,68 @@
 export enum Category {
     Location = 'Location',
-    LandUse = 'Land Use',
+    LandUse = 'LandUse',
     Type = 'Type',
     Age = 'Age',
-    SizeShape = 'Size & Shape',
+    SizeShape = 'SizeShape',
     Construction = 'Construction',
     Streetscape = 'Streetscape',
     Team = 'Team',
     Sustainability = 'Sustainability',
     Community = 'Community',
     Planning = 'Planning',
-    Like = 'Like Me!'
+    Like = 'Like',
 }
+
+export const categories = {
+    [Category.Location]: {
+        slug: 'location',
+        name: 'Location'
+    },
+    [Category.LandUse]: {
+        slug: 'use',
+        name: 'Land Use'
+    },
+    [Category.Type]: {
+        slug: 'type',
+        name: 'Type'
+    },
+    [Category.Age]: {
+        slug: 'age',
+        name: 'Age'
+    },
+    [Category.SizeShape]: {
+        slug: 'size',
+        name: 'Size & Shape'
+    },
+    [Category.Construction]: {
+        slug: 'construction',
+        name: 'Construction'
+    },
+    [Category.Streetscape]: {
+        slug: 'streetscape',
+        name: 'Streetscape'
+    },
+    [Category.Team]: {
+        slug: 'team',
+        name: 'Team'
+    },
+    [Category.Sustainability]: {
+        slug: 'sustainability',
+        name: 'Sustainability'
+    },
+    [Category.Community]: {
+        slug: 'community',
+        name: 'Community'
+    },
+    [Category.Planning]: {
+        slug: 'planning',
+        name: 'Planning'
+    },
+    [Category.Like]: {
+        slug: 'like',
+        name: 'Like Me!'
+    }
+};
 
 export const categoriesOrder: Category[] = [
     Category.Location,

--- a/app/src/frontend/models/edit-history-entry.ts
+++ b/app/src/frontend/models/edit-history-entry.ts
@@ -4,4 +4,5 @@ export interface EditHistoryEntry {
     revision_id: string;
     forward_patch: object;
     reverse_patch: object;
+    building_id?: number;
 }

--- a/app/src/frontend/pages/changes.tsx
+++ b/app/src/frontend/pages/changes.tsx
@@ -1,0 +1,41 @@
+import React, { useEffect, useState } from 'react';
+
+import { BuildingEditSummary } from '../building/edit-history/building-edit-summary';
+import { EditHistoryEntry } from '../models/edit-history-entry';
+
+const ChangesPage = () => {
+    const [history, setHistory] = useState<EditHistoryEntry[]>(undefined);
+
+    useEffect(() => {
+        const fetchData = async () => {
+            const res = await fetch(`/api/history`);
+            const data = await res.json();
+
+            setHistory(data.history);
+        };
+
+        fetchData();
+    }, []);
+    
+    return (
+        <article>
+            <section className="main-col">
+                <h1>Global edit history</h1>
+
+                <ul className="edit-history-list">
+                    {history && history.map(entry => (
+                        <li key={`${entry.revision_id}`} className="edit-history-list-element">
+                            <BuildingEditSummary
+                                historyEntry={entry}
+                                showBuildingId={true}
+                                hyperlinkCategories={true}
+                            />
+                        </li>
+                    ))}
+                </ul>
+            </section>
+        </article>
+    );
+};
+
+export default ChangesPage;


### PR DESCRIPTION
Resolves #499 

The screen is currently not linked to from the menu. Access through `colouring.london/history.html`. Currently will always display the last three weeks of changes. To be further developed.