### PR TITLE
Update node to v12.14.1

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: node_js
 node_js:
-  - 8
+  - 12
 cache: npm
 before_script:
   - cd $TRAVIS_BUILD_DIR/app && npm ci

--- a/app/package-lock.json
+++ b/app/package-lock.json
@@ -1189,9 +1189,9 @@
       "dev": true
     },
     "@types/node": {
-      "version": "8.10.59",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-8.10.59.tgz",
-      "integrity": "sha512-8RkBivJrDCyPpBXhVZcjh7cQxVBSmRk9QM7hOketZzp6Tg79c0N8kkpAIito9bnJ3HCVCHVYz+KHTEbfQNfeVQ==",
+      "version": "12.12.25",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-12.12.25.tgz",
+      "integrity": "sha512-nf1LMGZvgFX186geVZR1xMZKKblJiRfiASTHw85zED2kI1yDKHDwTKMdkaCbTlXoRKlGKaDfYywt+V0As30q3w==",
       "dev": true
     },
     "@types/nodemailer": {

--- a/app/package.json
+++ b/app/package.json
@@ -44,7 +44,7 @@
     "@types/jest": "^24.0.23",
     "@types/lodash": "^4.14.149",
     "@types/mapbox__sphericalmercator": "^1.1.3",
-    "@types/node": "^8.10.59",
+    "@types/node": "^12.12.25",
     "@types/nodemailer": "^6.2.2",
     "@types/prop-types": "^15.7.3",
     "@types/react": "^16.9.16",

--- a/docs/setup-dev-environment.md
+++ b/docs/setup-dev-environment.md
@@ -37,7 +37,7 @@ Now clone the colouring london codebase.
 Now install Node. It is helpful to define some local variables.
 
 ```
-NODE_VERSION=v8.11.3
+NODE_VERSION=v12.14.1
 DISTRO=linux-x64
 wget -nc https://nodejs.org/dist/$NODE_VERSION/node-$NODE_VERSION-$DISTRO.tar.xz
 sudo mkdir /usr/local/lib/node
@@ -137,7 +137,7 @@ root user profile. Don't forget to exit from root at the end.
 
 ```
 sudo su root
-export NODEJS_HOME=/usr/local/lib/node/node-v8.11.3/bin/`
+export NODEJS_HOME=/usr/local/lib/node/node-v12.14.1/bin/`
 export PATH=$NODEJS_HOME:$PATH`
 npm install -g npm@next`
 exit

--- a/docs/setup-production-environment.md
+++ b/docs/setup-production-environment.md
@@ -68,7 +68,7 @@ Now set appropriate permissions on the `colouring-london` directory
 
 First define a couple of convenience variables:
 
-`NODE_VERSION=v8.11.3`
+`NODE_VERSION=v12.14.1`
 
 `DISTRO=linux-x64`
 
@@ -107,7 +107,7 @@ Now upgrade the `npm` package manager to the most recent release with global pri
 
 `sudo su root`
 
-`export NODEJS_HOME=/usr/local/lib/node/node-v8.11.3/bin/`
+`export NODEJS_HOME=/usr/local/lib/node/node-v12.14.1/bin/`
 
 `export PATH=$NODEJS_HOME:$PATH`
 
@@ -240,7 +240,7 @@ Perform a global install of PM2
 
 `sudo su root`
 
-`export NODEJS_HOME=/usr/local/lib/node/node-v8.11.3/bin/`
+`export NODEJS_HOME=/usr/local/lib/node/node-v12.14.1/bin/`
 
 `export PATH=$NODEJS_HOME:$PATH`
 

--- a/provision/vm_provision.sh
+++ b/provision/vm_provision.sh
@@ -40,7 +40,7 @@ apt-get install -y \
 #
 
 # node version and platform
-NODE_VERSION=v8.11.3
+NODE_VERSION=v12.14.1
 DISTRO=linux-x64
 
 # download


### PR DESCRIPTION
Update node version to 12.14.1 (latest LTS). This resolves part of #531 but does not include the update to Postgres.
The @types/node package has also been updated, however there are currently no TypeScript types published for node v12.14 - only 12.12 or 13+ - so types for 12.12 were installed.