### PR TITLE
Wider definition of source coming from qualified people.

### DIFF
--- a/app/src/frontend/config/data-fields-config.ts
+++ b/app/src/frontend/config/data-fields-config.ts
@@ -7,7 +7,7 @@ let ccconfig: CCConfig = require('../../cc-config.json')
 */
 export const commonSourceTypes = [
     "Assessed by eye/personal knowledge of the building",
-    "Assessed using professional knowledge of building or building type",
+    "Assessed using expert knowledge of building or building type",
     "Assessed using streetview photographs, satellite imagery or maps",
     "Assessed by specialist emergency group",
     "Central government record/online database",


### PR DESCRIPTION
some experts are not professionals

`SELECT column_name FROM information_schema.columns WHERE table_name = 'buildings' and column_name LIKE '%source_type';`

was used to find columns where format changed

```
size_storeys_source_type
size_height_apex_source_type
size_height_eaves_source_type
size_floor_area_source_type
size_width_frontage_source_type
landowner_source_type
designers_source_type
builder_source_type
extension_source_type
size_far_ratio_source_type
size_plot_area_total_source_type
size_parcel_geometry_source_type
context_garden_source_type
context_street_width_source_type
context_pavement_width_source_type
context_green_space_distance_source_type
context_tree_distance_source_type
context_street_geometry_source_type
age_cladding_date_source_type
age_extension_date_source_type
age_retrofit_date_source_type
energy_solar_source_type
energy_green_roof_source_type
planning_crowdsourced_site_completion_source_type
date_source_type
planning_scientific_interest_source_type
typology_classification_source_type
typology_style_period_source_type
typology_dynamic_classification_source_type
typology_original_use_source_type
building_attachment_source_type
construction_structural_system_source_type
construction_foundation_source_type
construction_roof_shape_source_type
construction_irregularities_source_type
construction_roof_covering_source_type
construction_decorative_feature_source_type
construction_internal_wall_source_type
construction_external_wall_source_type
construction_ground_floor_source_type
construction_core_material_source_type
location_subdivisions_source_type
developer_source_type
designer_source_type
community_public_ownership_source_type
extension_developer_source_type
extension_designers_source_type
extension_builder_source_type
sust_breeam_rating_source_type
sust_energy_rating_source_type
building_client_source_type
extension_client_source_type
```

these columns should be edited, either by a database migration of by an automated script - not sure yet which is better